### PR TITLE
feat: add --minify option

### DIFF
--- a/src/Command/TailwindBuildCommand.php
+++ b/src/Command/TailwindBuildCommand.php
@@ -12,6 +12,7 @@ namespace Symfonycasts\TailwindBundle\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfonycasts\TailwindBundle\TailwindBuilder;
@@ -30,7 +31,10 @@ class TailwindBuildCommand extends Command
 
     protected function configure(): void
     {
-        $this->addOption('watch', 'w', null, 'Watch for changes and rebuild automatically');
+        $this
+            ->addOption('watch', 'w', null, 'Watch for changes and rebuild automatically')
+            ->addOption('minify', 'm', InputOption::VALUE_NONE, 'Minify the output CSS')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -39,7 +43,8 @@ class TailwindBuildCommand extends Command
         $this->tailwindBuilder->setOutput($io);
 
         $process = $this->tailwindBuilder->runBuild(
-            $input->getOption('watch'),
+            watch: $input->getOption('watch'),
+            minify: $input->getOption('minify'),
         );
         $process->wait(function ($type, $buffer) use ($io) {
             $io->write($buffer);

--- a/src/TailwindBuilder.php
+++ b/src/TailwindBuilder.php
@@ -30,12 +30,17 @@ class TailwindBuilder
     ) {
     }
 
-    public function runBuild(bool $watch): Process
-    {
+    public function runBuild(
+        bool $watch,
+        bool $minify,
+    ): Process {
         $binary = $this->createBinary();
         $arguments = ['-i', $this->inputPath, '-o', $this->getInternalOutputCssPath()];
         if ($watch) {
             $arguments[] = '--watch';
+        }
+        if ($minify) {
+            $arguments[] = '--minify';
         }
         $process = $binary->createProcess($arguments);
         if ($watch) {

--- a/tests/TailwindBuilderTest.php
+++ b/tests/TailwindBuilderTest.php
@@ -34,17 +34,41 @@ class TailwindBuilderTest extends TestCase
         }
     }
 
-    public function testIntegration(): void
+    public function testIntegrationWithDefaultOptions(): void
     {
         $builder = new TailwindBuilder(
             __DIR__.'/fixtures',
             __DIR__.'/fixtures/assets/styles/app.css',
             __DIR__.'/fixtures/var/tailwind'
         );
-        $process = $builder->runBuild(false);
+        $process = $builder->runBuild(watch: false, minify: false);
         $process->wait();
 
         $this->assertTrue($process->isSuccessful());
         $this->assertFileExists(__DIR__.'/fixtures/var/tailwind/tailwind.built.css');
+
+        $outputFileContents = file_get_contents(__DIR__.'/fixtures/var/tailwind/tailwind.built.css');
+        // Output should not be minified
+        $this->assertStringContainsString("body {\n  background-color: red;\n}", $outputFileContents);
+        $this->assertStringNotContainsString('body{background-color:red}', $outputFileContents);
+    }
+
+    public function testIntegrationWithMinify(): void
+    {
+        $builder = new TailwindBuilder(
+            __DIR__.'/fixtures',
+            __DIR__.'/fixtures/assets/styles/app.css',
+            __DIR__.'/fixtures/var/tailwind'
+        );
+        $process = $builder->runBuild(watch: false, minify: true);
+        $process->wait();
+
+        $this->assertTrue($process->isSuccessful());
+        $this->assertFileExists(__DIR__.'/fixtures/var/tailwind/tailwind.built.css');
+
+        // Output should be minified
+        $outputFileContents = file_get_contents(__DIR__.'/fixtures/var/tailwind/tailwind.built.css');
+        $this->assertStringNotContainsString("body {\n  background-color: red;\n}", $outputFileContents);
+        $this->assertStringContainsString('body{background-color:red}', $outputFileContents);
     }
 }

--- a/tests/fixtures/TailwindTestKernel.php
+++ b/tests/fixtures/TailwindTestKernel.php
@@ -39,6 +39,10 @@ class TailwindTestKernel extends Kernel
             'secret' => 'foo',
             'test' => true,
             'http_method_override' => true,
+            'handle_all_throwables' => true,
+            'php_errors' => [
+                'log' => true,
+            ],
             'asset_mapper' => [
                 'paths' => [
                     __DIR__.'/assets',

--- a/tests/fixtures/assets/styles/app.css
+++ b/tests/fixtures/assets/styles/app.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+    background-color: red;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | Close #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.),
this will help people understand your PR.
-->

Hi, this PR implements the `--minify` option of the standalone Tailwind binary.

Even if the [AssetMapper documentation](https://symfony.com/doc/current/frontend/asset_mapper.html#optimizing-performance) says that we can auto-minify generated assets by Cloudflare (or other CDNs), 
I think it's nice to have the possibility to minify Tailwind's output CSS file if we are not using any CDN.